### PR TITLE
Add quality-specific ad delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,9 @@ mvn spring-boot:run
 ```
 
 Requests to `/hls/{stream}.m3u8` and `/hls/{segment}.ts` will be fetched from the
-origin server. After a user has streamed for the configured duration, the playlist
-returned to that user will contain a discontinuity and three ad segments.
+origin server. You can also request a specific quality using
+`/hls/{quality}/{stream}.m3u8` and `/hls/{quality}/{segment}.ts`.
+Ad segments are available per quality at `/hls/ads/{quality}/{segment}.ts`.
+After a user has streamed for the configured duration, the playlist returned to
+that user will contain a discontinuity and three ad segments of the requested
+quality.

--- a/server/src/main/java/com/example/hls/HlsController.java
+++ b/server/src/main/java/com/example/hls/HlsController.java
@@ -33,7 +33,18 @@ public class HlsController {
     @GetMapping(path = "/{name}.m3u8", produces = "application/vnd.apple.mpegurl")
     public ResponseEntity<String> getPlaylist(@PathVariable String name, javax.servlet.http.HttpServletRequest request) {
         String user = request.getRemoteAddr();
-        String body = hlsService.getPlaylist(name, user);
+        String body = hlsService.getPlaylist(name, "", user);
+        logger.debug("Playlist {}", body);
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.noCache())
+                .contentType(MediaType.valueOf("application/vnd.apple.mpegurl"))
+                .body(body);
+    }
+
+    @GetMapping(path = "/{quality}/{name}.m3u8", produces = "application/vnd.apple.mpegurl")
+    public ResponseEntity<String> getPlaylistWithQuality(@PathVariable String quality, @PathVariable String name, javax.servlet.http.HttpServletRequest request) {
+        String user = request.getRemoteAddr();
+        String body = hlsService.getPlaylist(name, quality, user);
         logger.debug("Playlist {}", body);
         return ResponseEntity.ok()
                 .cacheControl(CacheControl.noCache())
@@ -44,17 +55,38 @@ public class HlsController {
     @GetMapping(value = "/{segment}.ts", produces = "video/MP2T")
     public ResponseEntity<Resource> getSegment(@PathVariable String segment, javax.servlet.http.HttpServletRequest request) {
         String user = request.getRemoteAddr();
-        byte[] data = hlsService.getSegment(segment, user);
+        byte[] data = hlsService.getSegment(segment, "", user);
         logger.debug("Serving segment {}", segment);
         return ResponseEntity.ok()
                 .cacheControl(CacheControl.noCache())
                 .body(new ByteArrayResource(data));
     }
 
+    @GetMapping(value = "/{quality}/{segment}.ts", produces = "video/MP2T")
+    public ResponseEntity<Resource> getSegmentWithQuality(@PathVariable String quality, @PathVariable String segment, javax.servlet.http.HttpServletRequest request) {
+        String user = request.getRemoteAddr();
+        byte[] data = hlsService.getSegment(segment, quality, user);
+        logger.debug("Serving segment {} for quality {}", segment, quality);
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.noCache())
+                .body(new ByteArrayResource(data));
+    }
+
     @GetMapping(value = "/ads/{segment}.ts", produces = "video/MP2T")
-    public ResponseEntity<Resource> getAdSegment(@PathVariable String segment) {
-        byte[] data = hlsService.getAdSegment(segment);
+    public ResponseEntity<Resource> getAdSegment(@PathVariable String segment, javax.servlet.http.HttpServletRequest request) {
+        String user = request.getRemoteAddr();
+        byte[] data = hlsService.getAdSegment(segment, "", user);
         logger.debug("Serving ad segment {}", segment);
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.noCache())
+                .body(new ByteArrayResource(data));
+    }
+
+    @GetMapping(value = "/ads/{quality}/{segment}.ts", produces = "video/MP2T")
+    public ResponseEntity<Resource> getAdSegmentWithQuality(@PathVariable String quality, @PathVariable String segment, javax.servlet.http.HttpServletRequest request) {
+        String user = request.getRemoteAddr();
+        byte[] data = hlsService.getAdSegment(segment, quality, user);
+        logger.debug("Serving ad segment {} for quality {}", segment, quality);
         return ResponseEntity.ok()
                 .cacheControl(CacheControl.noCache())
                 .body(new ByteArrayResource(data));

--- a/server/src/test/java/com/example/hls/SessionServiceTests.java
+++ b/server/src/test/java/com/example/hls/SessionServiceTests.java
@@ -1,0 +1,21 @@
+package com.example.hls;
+
+import com.example.hls.service.SessionService;
+import com.example.hls.model.Session;
+import com.example.hls.model.QualityMetrics;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SessionServiceTests {
+
+    @Test
+    void metricsAreUpdated() {
+        SessionService service = new SessionService();
+        service.updateMetrics("s1", "720p", "chunk0.ts", 100);
+        Session session = service.getSession("s1");
+        QualityMetrics metrics = session.getMetrics("720p");
+        assertEquals("chunk0.ts", metrics.getLastDownloadedChunk());
+        assertEquals(100, metrics.getDownloadedBytes());
+    }
+}


### PR DESCRIPTION
## Summary
- handle ad playlists per quality in `HlsService`
- expose `/ads/{quality}/{segment}.ts` endpoint in `HlsController`
- document quality aware ad endpoint

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*