### PR TITLE
Add redirect tests for session tokens

### DIFF
--- a/server/src/main/java/com/example/hls/service/session/SessionTokenService.java
+++ b/server/src/main/java/com/example/hls/service/session/SessionTokenService.java
@@ -1,0 +1,48 @@
+package com.example.hls.service.session;
+
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class SessionTokenService {
+    private static class TokenInfo {
+        final String mount;
+        final Instant expires;
+
+        TokenInfo(String mount, Instant expires) {
+            this.mount = mount;
+            this.expires = expires;
+        }
+    }
+
+    private final Map<String, TokenInfo> tokens = new ConcurrentHashMap<>();
+    private static final long EXPIRATION_SECONDS = 3600; // 1 hour
+
+    public String generateToken(String mount) {
+        String token = UUID.randomUUID().toString();
+        tokens.put(token, new TokenInfo(mount, Instant.now().plusSeconds(EXPIRATION_SECONDS)));
+        return token;
+    }
+
+    public boolean isValid(String token, String mount) {
+        if (token == null || token.isEmpty()) {
+            return false;
+        }
+        TokenInfo info = tokens.get(token);
+        if (info == null) {
+            return false;
+        }
+        if (!info.mount.equals(mount)) {
+            return false;
+        }
+        if (info.expires.isBefore(Instant.now())) {
+            tokens.remove(token);
+            return false;
+        }
+        return true;
+    }
+}

--- a/server/src/test/java/com/example/hls/HlsControllerTests.java
+++ b/server/src/test/java/com/example/hls/HlsControllerTests.java
@@ -1,0 +1,59 @@
+package com.example.hls;
+
+import com.example.hls.service.HlsService;
+import com.example.hls.service.session.SessionTokenService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(HlsController.class)
+class HlsControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private HlsService hlsService;
+
+    @MockBean
+    private SessionTokenService tokenService;
+
+    @BeforeEach
+    void setup() {
+        when(hlsService.getPlaylist(anyString(), anyString(), anyString())).thenReturn("playlist");
+        when(tokenService.generateToken(anyString())).thenReturn("newtoken");
+        when(tokenService.isValid(isNull(), anyString())).thenReturn(false);
+        when(tokenService.isValid(anyString(), anyString())).thenReturn(false);
+        when(tokenService.isValid(eq("validtoken"), anyString())).thenReturn(true);
+    }
+
+    @Test
+    void redirectsWhenTokenMissing() throws Exception {
+        mockMvc.perform(get("/hls/foo.m3u8"))
+                .andExpect(status().isTemporaryRedirect())
+                .andExpect(header().string("Location", startsWith("http://localhost/hls/foo.m3u8?zt=")));
+    }
+
+    @Test
+    void redirectsWhenTokenInvalid() throws Exception {
+        mockMvc.perform(get("/hls/foo.m3u8").param("zt", "bad"))
+                .andExpect(status().isTemporaryRedirect())
+                .andExpect(header().string("Location", startsWith("http://localhost/hls/foo.m3u8?zt=")));
+    }
+
+    @Test
+    void returnsPlaylistWhenTokenValid() throws Exception {
+        mockMvc.perform(get("/hls/foo.m3u8").param("zt", "validtoken"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("playlist"));
+    }
+}

--- a/server/src/test/java/com/example/hls/SessionTokenServiceTests.java
+++ b/server/src/test/java/com/example/hls/SessionTokenServiceTests.java
@@ -1,0 +1,18 @@
+package com.example.hls;
+
+import com.example.hls.service.session.SessionTokenService;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SessionTokenServiceTests {
+
+    @Test
+    void tokenIsValidated() {
+        SessionTokenService service = new SessionTokenService();
+        String token = service.generateToken("stream1");
+        assertTrue(service.isValid(token, "stream1"));
+        assertFalse(service.isValid(token, "other"));
+        assertFalse(service.isValid("bad", "stream1"));
+    }
+}


### PR DESCRIPTION
## Summary
- implement tests for HlsController redirect behaviour
- ensure playlist requests are redirected when session token is missing or invalid

## Testing
- `mvn test` *(fails: `bash: mvn: command not found`)*