### PR TITLE
Implement RTMP validation and FFmpeg startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This Spring Boot project demonstrates how to proxy HLS playlists and segments from a
 remote origin while inserting ad breaks.
 
+Requires **Java 21** to build and run.
+
 ### Configuration
 
 Edit `server/src/main/resources/application.properties` to point to your origin
@@ -13,7 +15,10 @@ hls.origin-base-url=http://localhost:8081/hls
 # hls.ad-base-url=http://localhost:8081/hls/ads
 hls.ad-frequency-minutes=2
 hls.segment-duration-seconds=5
+transcoder.output-path=live
 ```
+The configured `transcoder.output-path` will be combined with the stream name so
+HLS files are written under `<output-path>/<stream-name>`.
 
 ### Running
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -9,6 +9,9 @@
         <version>3.4.4</version>
         <relativePath/>
     </parent>
+    <properties>
+        <java.version>21</java.version>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -22,6 +25,14 @@
     </dependencies>
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <release>21</release>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/server/src/main/java/com/example/hls/HlsController.java
+++ b/server/src/main/java/com/example/hls/HlsController.java
@@ -3,7 +3,9 @@ package com.example.hls;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.example.hls.model.NginxRtmpRequest;
 import com.example.hls.service.HlsService;
+import com.example.hls.service.FfmpegService;
 import com.example.hls.service.session.SessionTokenService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
@@ -23,17 +25,22 @@ public class HlsController {
 
     private final HlsService hlsService;
     private final SessionTokenService tokenService;
+    private final FfmpegService ffmpegService;
 
     @Autowired
-    public HlsController(HlsService hlsService, SessionTokenService tokenService) {
+    public HlsController(HlsService hlsService, SessionTokenService tokenService, FfmpegService ffmpegService) {
         this.hlsService = hlsService;
         this.tokenService = tokenService;
+        this.ffmpegService = ffmpegService;
     }
 
 
     @PostMapping("/validate")
     public ResponseEntity<Void> validate(@RequestParam Map<String, String> params) {
-        logger.info("Validating key {}", params);
+        NginxRtmpRequest request = new NginxRtmpRequest(params);
+        logger.info("Validating key {}", request);
+        // start transcoding asynchronously after acknowledging the publish
+        ffmpegService.startTranscoding(request);
         return ResponseEntity.ok().build();
     }
 

--- a/server/src/main/java/com/example/hls/model/NginxRtmpRequest.java
+++ b/server/src/main/java/com/example/hls/model/NginxRtmpRequest.java
@@ -1,0 +1,33 @@
+package com.example.hls.model;
+
+import java.util.Map;
+
+/**
+ * Representation of the parameters passed by nginx-rtmp module hooks.
+ */
+public record NginxRtmpRequest(
+        String app,
+        String flashver,
+        String swfurl,
+        String tcurl,
+        String pageurl,
+        String addr,
+        String clientid,
+        String call,
+        String name,
+        String type) {
+
+    public NginxRtmpRequest(Map<String, String> params) {
+        this(
+                params.getOrDefault("app", ""),
+                params.getOrDefault("flashver", ""),
+                params.getOrDefault("swfurl", ""),
+                params.getOrDefault("tcurl", ""),
+                params.getOrDefault("pageurl", ""),
+                params.getOrDefault("addr", ""),
+                params.getOrDefault("clientid", ""),
+                params.getOrDefault("call", ""),
+                params.getOrDefault("name", ""),
+                params.getOrDefault("type", ""));
+    }
+}

--- a/server/src/main/java/com/example/hls/service/FfmpegService.java
+++ b/server/src/main/java/com/example/hls/service/FfmpegService.java
@@ -1,0 +1,96 @@
+package com.example.hls.service;
+
+import com.example.hls.model.NginxRtmpRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Service responsible for spawning ffmpeg to transcode RTMP streams into HLS.
+ */
+@Service
+public class FfmpegService {
+    private static final Logger logger = LoggerFactory.getLogger(FfmpegService.class);
+
+    @Value("${transcoder.output-path:live}")
+    private String outputPath;
+
+    public void startTranscoding(NginxRtmpRequest request) {
+        String inputUrl = request.tcurl() + "/" + request.name();
+        String streamOutput = String.format("%s/%s", outputPath, request.name());
+        List<String> cmd = buildCommand(inputUrl, streamOutput);
+        runAsync(cmd);
+    }
+
+    private List<String> buildCommand(String inputUrl, String streamPath) {
+        List<String> command = new ArrayList<>();
+        command.add("ffmpeg");
+        command.add("-i");
+        command.add(inputUrl);
+
+        // 720p
+        command.add("-map"); command.add("0:v");
+        command.add("-s:v:0"); command.add("1280x720");
+        command.add("-c:v:0"); command.add("libx264");
+        command.add("-b:v:0"); command.add("2500k");
+        command.add("-preset"); command.add("veryfast");
+        command.add("-g"); command.add("48");
+        command.add("-sc_threshold"); command.add("0");
+        command.add("-keyint_min"); command.add("48");
+
+        // 360p
+        command.add("-map"); command.add("0:v");
+        command.add("-s:v:1"); command.add("640x360");
+        command.add("-c:v:1"); command.add("libx264");
+        command.add("-b:v:1"); command.add("800k");
+        command.add("-preset"); command.add("veryfast");
+        command.add("-g"); command.add("48");
+        command.add("-sc_threshold"); command.add("0");
+        command.add("-keyint_min"); command.add("48");
+
+        // 480p
+        command.add("-map"); command.add("0:v");
+        command.add("-s:v:2"); command.add("854x480");
+        command.add("-c:v:2"); command.add("libx264");
+        command.add("-b:v:2"); command.add("1400k");
+        command.add("-preset"); command.add("veryfast");
+        command.add("-g"); command.add("48");
+        command.add("-sc_threshold"); command.add("0");
+        command.add("-keyint_min"); command.add("48");
+
+        command.add("-var_stream_map");
+        command.add("v:0,name:720p v:1,name:360p v:2,name:480p");
+        command.add("-master_pl_name"); command.add("master.m3u8");
+        command.add("-hls_segment_filename");
+        command.add(String.format("%s/%%v/segment_%%03d.ts", streamPath));
+        command.add("-f"); command.add("hls");
+        command.add("-hls_time"); command.add("4");
+        command.add("-hls_flags"); command.add("delete_segments+append_list+independent_segments");
+        command.add("-hls_list_size"); command.add("20");
+        command.add(String.format("%s/%%v/playlist.m3u8", streamPath));
+        return command;
+    }
+
+    private void runAsync(List<String> command) {
+        CompletableFuture.runAsync(() -> {
+            ProcessBuilder pb = new ProcessBuilder(command);
+            pb.redirectErrorStream(true);
+            try {
+                logger.info("Starting ffmpeg command: {}", String.join(" ", command));
+                Process p = pb.start();
+                int exit = p.waitFor();
+                logger.info("ffmpeg exited with status {}", exit);
+            } catch (IOException | InterruptedException e) {
+                Thread.currentThread().interrupt();
+                logger.error("ffmpeg execution failed", e);
+            }
+        }, CompletableFuture.delayedExecutor(1, TimeUnit.SECONDS));
+    }
+}

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -4,3 +4,4 @@ hls.origin-base-url=http://127.0.0.1/hls
 hls.ad-base-url=http://127.0.0.1/ads
 hls.ad-frequency-minutes=2
 hls.segment-duration-seconds=5
+transcoder.output-path=live

--- a/server/src/test/java/com/example/hls/HlsControllerTests.java
+++ b/server/src/test/java/com/example/hls/HlsControllerTests.java
@@ -1,6 +1,7 @@
 package com.example.hls;
 
 import com.example.hls.service.HlsService;
+import com.example.hls.service.FfmpegService;
 import com.example.hls.service.session.SessionTokenService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,9 @@ class HlsControllerTests {
 
     @MockBean
     private SessionTokenService tokenService;
+
+    @MockBean
+    private FfmpegService ffmpegService;
 
     @BeforeEach
     void setup() {


### PR DESCRIPTION
## Summary
- create `NginxRtmpRequest` as a Java record for nginx RTMP parameters
- make `FfmpegService` combine output path with stream name and run ffmpeg via `CompletableFuture`
- require Java 21 in Maven build and document it in README

## Testing
- `mvn -q test` *(fails: `mvn` not found)*