### PR TITLE
Implement audio-only streaming

### DIFF
--- a/server/src/main/java/com/example/hls/controller/AudioHlsController.java
+++ b/server/src/main/java/com/example/hls/controller/AudioHlsController.java
@@ -1,0 +1,111 @@
+package com.example.hls.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.example.hls.model.NginxRtmpRequest;
+import com.example.hls.service.HlsService;
+import com.example.hls.service.FfmpegService;
+import com.example.hls.service.session.SessionTokenService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.CacheControl;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/live/audio")
+public class AudioHlsController {
+    private static final Logger logger = LoggerFactory.getLogger(AudioHlsController.class);
+
+    private final HlsService hlsService;
+    private final SessionTokenService tokenService;
+    private final FfmpegService ffmpegService;
+
+    @Autowired
+    public AudioHlsController(HlsService hlsService, SessionTokenService tokenService, FfmpegService ffmpegService) {
+        this.hlsService = hlsService;
+        this.tokenService = tokenService;
+        this.ffmpegService = ffmpegService;
+    }
+
+    @PostMapping("/validate")
+    public ResponseEntity<Void> validate(@RequestParam Map<String, String> params) {
+        NginxRtmpRequest request = new NginxRtmpRequest(params);
+        logger.info("Validating audio stream {}", request);
+        ffmpegService.startAudioTranscoding(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/done")
+    public ResponseEntity<Void> done(@RequestParam Map<String, String> params) {
+        logger.info("Audio stream ended {}", params);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping(path = "/{stream}/{playlist}.m3u8", produces = "application/vnd.apple.mpegurl")
+    public ResponseEntity<?> getPlaylist(@PathVariable String stream, @PathVariable String playlist, HttpServletRequest request) {
+        String user = request.getRemoteAddr();
+        String body = hlsService.getPlaylist(stream, playlist, "", user);
+        logger.debug("Audio playlist {}", body);
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.noCache())
+                .contentType(MediaType.valueOf("application/vnd.apple.mpegurl"))
+                .body(body);
+    }
+
+    @GetMapping(path = "{stream}/{quality}/{playlist}.m3u8", produces = "application/vnd.apple.mpegurl")
+    public ResponseEntity<?> getPlaylistWithQuality(@PathVariable String stream, @PathVariable String quality, @PathVariable String playlist, HttpServletRequest request) {
+        String user = request.getRemoteAddr();
+        String body = hlsService.getPlaylist(stream, playlist, quality, user);
+        logger.debug("Audio playlist {}", body);
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.noCache())
+                .contentType(MediaType.valueOf("application/vnd.apple.mpegurl"))
+                .body(body);
+    }
+
+    @GetMapping(value = "{stream}/{segment}.aac", produces = "audio/aac")
+    public ResponseEntity<Resource> getSegment(@PathVariable String stream, @PathVariable String segment, HttpServletRequest request) {
+        String user = request.getRemoteAddr();
+        byte[] data = hlsService.getAudioSegment(stream, segment, "", user);
+        logger.debug("Serving audio segment {}", segment);
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.noCache())
+                .body(new ByteArrayResource(data));
+    }
+
+    @GetMapping(value = "{stream}/{quality}/{segment}.aac", produces = "audio/aac")
+    public ResponseEntity<Resource> getSegmentWithQuality(@PathVariable String stream, @PathVariable String quality, @PathVariable String segment, HttpServletRequest request) {
+        String user = request.getRemoteAddr();
+        byte[] data = hlsService.getAudioSegment(stream, segment, quality, user);
+        logger.debug("Serving audio segment {} for quality {}", segment, quality);
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.noCache())
+                .body(new ByteArrayResource(data));
+    }
+
+    @GetMapping(value = "{stream}/{quality}/ads/{segment}.aac", produces = "audio/aac")
+    public ResponseEntity<Resource> getAdSegment(@PathVariable String stream, @PathVariable String segment, HttpServletRequest request) {
+        String user = request.getRemoteAddr();
+        byte[] data = hlsService.getAudioAdSegment(segment, "", user);
+        logger.debug("Serving audio ad segment {}", segment);
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.noCache())
+                .body(new ByteArrayResource(data));
+    }
+
+    @GetMapping(value = "{stream}/{quality}/ads/{ad_quality}/{segment}.aac", produces = "audio/aac")
+    public ResponseEntity<Resource> getAdSegmentWithQuality(@PathVariable String stream, @PathVariable String ad_quality, @PathVariable String segment, HttpServletRequest request) {
+        String user = request.getRemoteAddr();
+        byte[] data = hlsService.getAudioAdSegment(segment, ad_quality, user);
+        logger.debug("Serving audio ad segment {} for quality {}", segment, ad_quality);
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.noCache())
+                .body(new ByteArrayResource(data));
+    }
+}

--- a/server/src/test/java/com/example/hls/AudioHlsControllerTests.java
+++ b/server/src/test/java/com/example/hls/AudioHlsControllerTests.java
@@ -1,0 +1,53 @@
+package com.example.hls;
+
+import com.example.hls.controller.AudioHlsController;
+import com.example.hls.service.HlsService;
+import com.example.hls.service.FfmpegService;
+import com.example.hls.service.session.SessionTokenService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AudioHlsController.class)
+class AudioHlsControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private HlsService hlsService;
+
+    @MockBean
+    private SessionTokenService tokenService;
+
+    @MockBean
+    private FfmpegService ffmpegService;
+
+    @BeforeEach
+    void setup() {
+        when(hlsService.getPlaylist(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn("playlist");
+    }
+
+    @Test
+    void returnsPlaylist() throws Exception {
+        mockMvc.perform(get("/live/audio/foo/playlist.m3u8"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("playlist"));
+    }
+
+    @Test
+    void returnsPlaylistWithQuality() throws Exception {
+        mockMvc.perform(get("/live/audio/foo/high/playlist.m3u8"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("playlist"));
+    }
+}


### PR DESCRIPTION
## Summary
- support audio-only transcoding in `FfmpegService`
- expose audio streaming endpoints via new `AudioHlsController`
- add audio helpers in `HlsService`
- cover audio controller with tests

## Testing
- `mvn -q -DskipTests=false test` *(fails: `mvn: command not found`)*