### PR TITLE
Use WebClient and add JsonConverter

### DIFF
--- a/server/src/main/java/com/example/hls/config/AdMediaConfiguration.java
+++ b/server/src/main/java/com/example/hls/config/AdMediaConfiguration.java
@@ -1,13 +1,8 @@
 package com.example.hls.config;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.web.client.RestTemplate;
 
-import java.time.Duration;
 
 @Configuration
 public class AdMediaConfiguration {

--- a/server/src/main/java/com/example/hls/util/ConverterException.java
+++ b/server/src/main/java/com/example/hls/util/ConverterException.java
@@ -1,0 +1,7 @@
+package com.example.hls.util;
+
+public class ConverterException extends RuntimeException {
+    public ConverterException(Object value, Class<?> targetType) {
+        super("Failed to convert " + value + " to " + targetType.getSimpleName());
+    }
+}

--- a/server/src/main/java/com/example/hls/util/JsonConverter.java
+++ b/server/src/main/java/com/example/hls/util/JsonConverter.java
@@ -1,0 +1,68 @@
+package com.example.hls.util;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+public final class JsonConverter {
+    private final ObjectMapper objectMapper;
+
+    public JsonConverter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public <T> T convert(Object from, final Class<T> clazz) {
+        try {
+            return objectMapper.convertValue(from, clazz);
+        } catch (Exception e) {
+            throw new ConverterException(from, clazz);
+        }
+    }
+
+    public <T> T deserializeJson(String val, final Class<T> clazz) {
+        if (Objects.isNull(val)) {
+            throw new ConverterException("null value", clazz);
+        }
+        try {
+            return objectMapper.readValue(val, clazz);
+        } catch (Exception e) {
+            throw new ConverterException(val, clazz);
+        }
+    }
+
+    public <T> T deserializeJson(String val, TypeReference<T> ref) {
+        if (Objects.isNull(val)) {
+            throw new ConverterException("null value", Object.class);
+        }
+        try {
+            return objectMapper.readValue(val, ref);
+        } catch (Exception e) {
+            throw new ConverterException(val, Object.class);
+        }
+    }
+
+    public String serializeJson(Object val) {
+        if (Objects.isNull(val)) {
+            return "";
+        }
+        try {
+            return objectMapper.writeValueAsString(val);
+        } catch (Exception e) {
+            throw new ConverterException(val, String.class);
+        }
+    }
+
+    public byte[] serializeBytes(Object val) {
+        if (Objects.isNull(val)) {
+            return new byte[0];
+        }
+        try {
+            return objectMapper.writeValueAsBytes(val);
+        } catch (Exception e) {
+            throw new ConverterException(val, byte[].class);
+        }
+    }
+}

--- a/server/src/test/java/com/example/hls/AdMediaServiceTests.java
+++ b/server/src/test/java/com/example/hls/AdMediaServiceTests.java
@@ -5,28 +5,22 @@ import com.example.hls.model.ad.AdResponse;
 import com.example.hls.model.ad.SessionContext;
 import com.example.hls.service.AdMediaService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.example.hls.util.JsonConverter;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.test.web.client.MockRestServiceServer;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
 
 class AdMediaServiceTests {
 
     @Test
     void getAdReturnsResponse() throws Exception {
-        RestTemplate restTemplate = new RestTemplate();
-        MockRestServiceServer server = MockRestServiceServer.createServer(restTemplate);
-
         AdMediaConfiguration config = new AdMediaConfiguration();
-        ReflectionTestUtils.setField(config, "adProviderUrl", "http://ads");
-
-        AdMediaService service = new AdMediaService(restTemplate, config, new ObjectMapper());
 
         AdResponse expected = new AdResponse();
         expected.setId("123");
@@ -34,52 +28,60 @@ class AdMediaServiceTests {
         ObjectMapper mapper = new ObjectMapper();
         String body = mapper.writeValueAsString(expected);
 
-        server.expect(requestTo("http://ads?breakId=b1&zoneId=PREROLL&duration=30"))
-                .andExpect(method(HttpMethod.POST))
-                .andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+        DisposableServer server = HttpServer.create()
+                .port(0)
+                .handle((req, res) -> res.status(200)
+                        .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .sendString(Mono.just(body)))
+                .bindNow();
+
+        ReflectionTestUtils.setField(config, "adProviderUrl", "http://localhost:" + server.port());
+
+        WebClient client = WebClient.builder().baseUrl("http://localhost:" + server.port()).build();
+        AdMediaService service = new AdMediaService(client, config, new JsonConverter(new ObjectMapper()));
 
         AdResponse response = service.getAd("b1", 30L, true, new SessionContext("s1", "1.1.1.1"));
 
         assertEquals("123", response.getId());
-        server.verify();
+        server.disposeNow();
     }
 
     @Test
     void getAdHandlesError() {
-        RestTemplate restTemplate = new RestTemplate();
-        MockRestServiceServer server = MockRestServiceServer.createServer(restTemplate);
-
         AdMediaConfiguration config = new AdMediaConfiguration();
-        ReflectionTestUtils.setField(config, "adProviderUrl", "http://ads");
 
-        AdMediaService service = new AdMediaService(restTemplate, config, new ObjectMapper());
+        DisposableServer server = HttpServer.create()
+                .port(0)
+                .handle((req, res) -> res.status(500).send())
+                .bindNow();
 
-        server.expect(requestTo("http://ads?breakId=b1&zoneId=PREROLL&duration=30"))
-                .andExpect(method(HttpMethod.POST))
-                .andRespond(withServerError());
+        ReflectionTestUtils.setField(config, "adProviderUrl", "http://localhost:" + server.port());
+
+        WebClient client = WebClient.builder().baseUrl("http://localhost:" + server.port()).build();
+        AdMediaService service = new AdMediaService(client, config, new JsonConverter(new ObjectMapper()));
 
         AdResponse response = service.getAd("b1", 30L, true, new SessionContext("s1", "1.1.1.1"));
 
         assertNull(response.getId());
         assertTrue(response.getAdDetailsList().isEmpty());
-        server.verify();
+        server.disposeNow();
     }
 
     @Test
     void skipNextPosts() {
-        RestTemplate restTemplate = new RestTemplate();
-        MockRestServiceServer server = MockRestServiceServer.createServer(restTemplate);
-
         AdMediaConfiguration config = new AdMediaConfiguration();
-        ReflectionTestUtils.setField(config, "adProviderUrl", "http://ads");
 
-        AdMediaService service = new AdMediaService(restTemplate, config, new ObjectMapper());
+        DisposableServer server = HttpServer.create()
+                .port(0)
+                .handle((req, res) -> res.status(200).send())
+                .bindNow();
 
-        server.expect(requestTo("http://ads/skip-next"))
-                .andExpect(method(HttpMethod.POST))
-                .andRespond(withSuccess());
+        ReflectionTestUtils.setField(config, "adProviderUrl", "http://localhost:" + server.port());
+
+        WebClient client = WebClient.builder().baseUrl("http://localhost:" + server.port()).build();
+        AdMediaService service = new AdMediaService(client, config, new JsonConverter(new ObjectMapper()));
 
         service.skipNext(new SessionContext("s1", "1.1.1.1"));
-        server.verify();
+        server.disposeNow();
     }
 }


### PR DESCRIPTION
## Summary
- replace RestTemplate with WebClient in `AdMediaService`
- introduce `JsonConverter` helper and `ConverterException`
- update configuration imports
- adjust tests to use Reactor Netty `HttpServer`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c77b443d483209494a6cd07eb39d8